### PR TITLE
feat(autofill): random phone number can not have "0" as second digit

### DIFF
--- a/src/lib/services/fakeDataService.test.ts
+++ b/src/lib/services/fakeDataService.test.ts
@@ -34,6 +34,14 @@ describe("FakeDataService tests", () => {
     expect(phone).not.toEqual(FakeDataService.phone());
   });
 
+  it('phone should return a random phone number without "0" as second phone digit', () => {
+    for(let i = 0; i < 1000; i++) {
+      const phone = FakeDataService.phone();
+      expect(phone).toMatch(/^(\+39)?\d{10}$/);
+      expect(phone[1]).not.toEqual("0");
+    }
+  });
+
   it("street should return a random street name", () => {
     const street = FakeDataService.street();
     expect(street).toBeTypeOf("string");

--- a/src/lib/services/fakeDataService.ts
+++ b/src/lib/services/fakeDataService.ts
@@ -85,7 +85,11 @@ class FakeDataService {
   }
 
   public static phone() {
-    return "3" + faker.string.numeric({ length: 9 });
+    let phoneNumber: string;
+    do {
+      phoneNumber = "3" + faker.string.numeric({ length: 9 });
+    } while (phoneNumber[1]==="0")
+    return phoneNumber;
   }
 
   public static street() {


### PR DESCRIPTION
# Problem
Phone number having "0" as second digit is not accepted by the bis-tech-extension target application

![Screenshot 2024-01-22 at 09 29 48](https://github.com/giuxtaposition/bis-tech-extension/assets/80199004/d189b746-0557-44d3-be74-06cfc855dc5a)

# Solution
when a phone number with "0" as the second digit is randomly generated, a new random generation is performed
