### PR TITLE
fix: prevent uncheck already checked privacy policy

### DIFF
--- a/src/lib/pages/life/yourOfferPage.ts
+++ b/src/lib/pages/life/yourOfferPage.ts
@@ -15,6 +15,7 @@ export default class YourOfferPage extends Page {
     this.changeInputValue(this.surname, FakeDataService.lastName());
     this.changeInputValue(this.email, FakeDataService.email());
     this.changeInputValue(this.phone, FakeDataService.phone());
-    this.clickInputElement(this.privacyPolicy);
+    if (!this.getInput(this.privacyPolicy).checked)
+      this.clickInputElement(this.privacyPolicy);
   }
 }


### PR DESCRIPTION
## Problem
Currently privacy policy in your offer page is already checked landing from previous page.

When fill your offer page, the actual implementation uncheck privacy policy checkbox preventing you from proceeding to the next page.

## Solution

Click on privacy policy checkbox only when is not already checked.

We could remove click but:
- if the privacy policy behaviour change again, we have to reintroduce the click.
- if someone uncheck the privacy policy and than use the autofill, this implementation ensures that the expected behavior is achieved.
